### PR TITLE
feat: external object props

### DIFF
--- a/objects/sandbox-example/src/App.svelte
+++ b/objects/sandbox-example/src/App.svelte
@@ -9,7 +9,6 @@
   onMount(() => {
     startEventListener({ 
       onContextChange: async (stateProps, contextProps) => {
-        console.debug('onContextChange', { stateProps, contextProps })
         const adapter = makeWakuObjectAdapter()
         const context = makeWakuObjectContext(adapter, contextProps)
         args = {
@@ -42,8 +41,6 @@
     const transaction = await context.getTransaction('0x46593fe25fadddd0bb3feb3017b8745a471d61e5c650c3dc5c0920f46216d0b6')
     console.debug('sandbox-example: action', { transaction })
   }
-
-  $: { console.debug({ args }) }
 </script>
 
 <div>

--- a/packages/adapter/src/index.ts
+++ b/packages/adapter/src/index.ts
@@ -210,7 +210,6 @@ interface EventListenerOptions {
 export function startEventListener(options: Partial<EventListenerOptions>) {
   // Start listener
   window.addEventListener("message", (event) => {
-    console.debug('adapter sdk', { event })
     // Check if the message came from the parent (chat app)
     /*
     if (event.origin !== "null" || event.source !== parent.contentWindow) {
@@ -258,6 +257,8 @@ export function startEventListener(options: Partial<EventListenerOptions>) {
 
     defer.resolve(data.result.value);
   });
+
+  // send `init` message after object side initialization is complete
+  // the host application will respond with the updated context
   parent.postMessage({ type: 'init' }, '*')
-  console.debug('startEventListener finished')
 }

--- a/packages/adapter/src/index.ts
+++ b/packages/adapter/src/index.ts
@@ -1,5 +1,5 @@
 import pDefer, { DeferredPromise } from "p-defer";
-import { DataMessage, JSONSerializable, Token, TokenSchema, TransactionSchema, TransactionStateSchema, WakuObjectAdapter, WakuObjectArgs, WakuObjectContext, WakuObjectState } from './types'
+import { DataMessage, JSONSerializable, Token, TokenSchema, TransactionSchema, TransactionStateSchema, WakuObjectAdapter, WakuObjectArgs, WakuObjectContext, WakuObjectContextProps, WakuObjectState } from './types'
 import { Contract } from "ethers";
 
 interface AdapterRequestMessage {
@@ -31,11 +31,13 @@ export interface IframeDataMessage {
 	type: 'iframe-data-message'
 	message: DataMessage
   state: WakuObjectState
+  context: WakuObjectContextProps
 }
 
-export interface IframeStartMessage {
-  type: 'iframe-start-message'
+export interface IframeContextChange {
+  type: 'iframe-context-change'
   state: WakuObjectState
+  context: WakuObjectContextProps
 }
 
 // Store
@@ -70,6 +72,10 @@ const adapterFunction = (name: string) => (...args: string[]) => {
 
 function isIframeDataMessage(message: any): message is IframeDataMessage {
   return typeof message == "object" && message?.type === "iframe-data-message"
+}
+
+function isIframeContextChange(message: any): message is IframeContextChange {
+  return typeof message == "object" && message?.type === 'iframe-context-change'
 }
 
 const isAdapterResponseMessage = (message: any): message is AdapterResponseMessage => {
@@ -166,7 +172,7 @@ export function makeWakuObjectAdapter(): WakuObjectAdapter {
   }
 }
 
-export function makeWakuObjectContext(adapter: WakuObjectAdapter): WakuObjectContext {
+export function makeWakuObjectContext(adapter: WakuObjectAdapter, contextProps?: Partial<WakuObjectContextProps>): WakuObjectContext {
   async function send(data: JSONSerializable) {
     const response = await adapterFunction('send')(JSON.stringify(data))
     if (!response) {
@@ -189,6 +195,7 @@ export function makeWakuObjectContext(adapter: WakuObjectAdapter): WakuObjectCon
 
   return {
     ...adapter,
+    ...contextProps,
     send,
     updateStore,
     onViewChange,
@@ -197,6 +204,7 @@ export function makeWakuObjectContext(adapter: WakuObjectAdapter): WakuObjectCon
 
 interface EventListenerOptions {
   onDataMessage: (dataMessage: DataMessage, args: WakuObjectArgs) => Promise<void>
+  onContextChange: (state: WakuObjectState, context: WakuObjectContextProps) => Promise<void>
 }
 
 export function startEventListener(options: Partial<EventListenerOptions>) {
@@ -215,7 +223,7 @@ export function startEventListener(options: Partial<EventListenerOptions>) {
     if (isIframeDataMessage(data)) {
       const message = data.message as DataMessage
       const adapter = makeWakuObjectAdapter()
-      const context = makeWakuObjectContext(adapter)
+      const context = makeWakuObjectContext(adapter, data.context)
       const args: WakuObjectArgs = {
         ...context,
         ...data.state
@@ -224,6 +232,12 @@ export function startEventListener(options: Partial<EventListenerOptions>) {
         options.onDataMessage(message, args)
       }
       return
+    }
+
+    if (isIframeContextChange(data)) {
+      if (options.onContextChange) {
+        options.onContextChange(data.state, data.context)
+      }
     }
 
     if (!isAdapterResponseMessage(data)) {
@@ -244,5 +258,6 @@ export function startEventListener(options: Partial<EventListenerOptions>) {
 
     defer.resolve(data.result.value);
   });
-
+  parent.postMessage({ type: 'init' }, '*')
+  console.debug('startEventListener finished')
 }

--- a/packages/adapter/src/types.ts
+++ b/packages/adapter/src/types.ts
@@ -69,7 +69,7 @@ export interface JSONArray extends Array<JSONValue> {}
 
 export type JSONValue = JSONPrimitive | JSONObject | JSONArray
 
-export type JSONSerializable = JSONValue
+export type JSONSerializable = JSONValue 
 
 export interface WakuObjectState {
 	readonly chatId: string
@@ -83,24 +83,29 @@ export interface WakuObjectState {
 type StoreType = JSONSerializable
 type DataMessageType = JSONSerializable
 
-export interface WakuObjectContext extends WakuObjectAdapter {
+export interface WakuObjectContextProps {
 	readonly store?: StoreType
+	readonly view?: string
+}
+
+export interface WakuObjectContext extends WakuObjectContextProps, WakuObjectAdapter {
 	updateStore: (updater: (state?: StoreType) => StoreType) => void
 
 	send: (data: DataMessageType) => Promise<void>
 
-	readonly view?: string
 	onViewChange: (view: string) => void
 }
 
 export interface WakuObjectArgs extends WakuObjectContext, WakuObjectState {}
 
-export interface WakuObjectDescriptor {
+interface WakuObjectMetadata {
 	readonly objectId: string
 	readonly name: string
 	readonly description: string
 	readonly logo: string
+}
 
+export interface WakuObjectDescriptor extends WakuObjectMetadata {
 	onMessage?: (message: DataMessage<DataMessageType>, args: WakuObjectArgs) => Promise<void>
 }
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1,5 +1,9 @@
 lockfileVersion: '6.0'
 
+settings:
+  autoInstallPeers: true
+  excludeLinksFromLockfile: false
+
 importers:
 
   .:


### PR DESCRIPTION
This PR adds a new message type so that the `args` (the reactive props of the object) are properly updated every time they change in the host application. There is also a new initial message (called `init`) when the initialization code is finished in the iframe, sent to the host application that sends back the `args`.

There are also some improvements in the svelte app, like the `window-size` message is sent when the svelte updates the DOM. Those changes would be done best in a `svelte-adapter` package that svelte projects could import so that they don't have to write all the boilerplate.